### PR TITLE
Fix bad links in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,15 +47,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/libsql/libsql.git"
+    "url": "git+https://github.com/tursodatabase/libsql-js.git"
   },
   "keywords": [
     "libsql"
   ],
   "bugs": {
-    "url": "https://github.com/libsql/libsql/issues"
+    "url": "https://github.com/tursodatabase/libsql-js/issues"
   },
-  "homepage": "https://github.com/libsql/libsql",
+  "homepage": "https://github.com/tursodatabase/libsql-js",
   "devDependencies": {
     "@neon-rs/cli": "^0.0.165"
   },


### PR DESCRIPTION
I'm trying to help someone who encountered a bug in https://npmjs.com/package/libsql and went on quite the wild goose chasing trying to find where its code lives since, as far as I can tell, it's pointing to the wrong repository