### PR TITLE
Statically import libsql targets

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,9 +39,48 @@ const {
   statementColumns,
   statementSafeIntegers,
   rowsNext,
-} = require(`@libsql/${target}`);
+} = requireLibsql(target);
 
 const SqliteError = require("./sqlite-error");
+
+/**
+ * Statically require the correct libsql for the given target.
+ * Workaround for bundlers that don't support dynamic requires.
+ * e.g.: Bun single-executable build mode.
+ * @param {*} target
+ * @returns
+ */
+function requireLibsql(target) {
+  if (target === "darwin-arm64") {
+    return require("@libsql/darwin-arm64");
+  }
+
+  if (target === "darwin-x64") {
+    return require("@libsql/darwin-x64");
+  }
+
+  if (target === "linux-arm64-gnu") {
+    return require("@libsql/linux-arm64-gnu");
+  }
+
+  if (target === "linux-arm64-musl") {
+    return require("@libsql/linux-arm64-musl");
+  }
+
+  if (target === "linux-x64-gnu") {
+    return require("@libsql/linux-x64-gnu");
+  }
+
+  if (target === "linux-x64-musl") {
+    return require("@libsql/linux-x64-musl");
+  }
+
+  if (target === "win32-x64-msvc") {
+    return require("@libsql/win32-x64-msvc");
+  }
+
+  throw new Error(`Unsupported target: ${target}`);
+}
 
 /**
  * Database represents a connection that can prepare and execute SQL statements.
@@ -99,7 +138,7 @@ class Database {
   prepare(sql) {
     try {
       const stmt = databasePrepareSync.call(this.db, sql);
-      return new Statement(stmt);  
+      return new Statement(stmt);
     } catch (err) {
       throw new SqliteError(err.message, err.code, err.rawCode);
     }


### PR DESCRIPTION
I am not sure if there are more targets, but developing with bun using the [single-file executable mode](https://bun.sh/docs/bundler/executables) the libsql driver fails to be imported from the embedded file system as Bun doesn't detect what files are to be imported if done dynamically.

As the code dynamically imports the proper target module we can get a false positive if the built file is run in a project that has the `node_modules/@libsql/*` target folders so it's recommended to test this by copying the binary file to another directory or simply running it from somewhere else:

e.g:
![image](https://github.com/tursodatabase/libsql-js/assets/35346082/ff42f903-3064-4a7d-a8e6-a08f74f13835)

Image Error Transcript:
```
error: Cannot find module "@libsql/linux-x64-gnu" from "/$bunfs/root/test-build"
```