### PR TITLE
`package.json`: add "types" to "exports"

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
     "types/index.d.ts"
   ],
   "exports": {
-    ".": "./index.js",
+    ".": {
+      "types": "./types/index.d.ts",
+      "default": "./index.js"
+    },
     "./promise": "./promise.js"
   },
   "scripts": {


### PR DESCRIPTION
According to the [Typescript Docs](https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports), TS expects to find a `"types"` property in the package.json `"exports"` declaration
> When moduleResolution is set to node16, nodenext, or bundler, and resolvePackageJsonExports is not disabled, TypeScript follows Node.js’s [package.json "exports" spec](https://nodejs.org/api/packages.html#packages_package_entry_points) when resolving from a package directory triggered by a [bare specifier node_modules package lookup](https://www.typescriptlang.org/docs/handbook/modules/reference.html#node_modules-package-lookups).

Because `libsql-js` does not, I receive this error:

```
Could not find a declaration file for module 'libsql'. '/node_modules/.pnpm/libsql@0.3.9/node_modules/libsql/index.js' implicitly has an 'any' type.
  There are types at '/node_modules/libsql/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'libsql' library may need to update its package.json or typings.ts
```

I have tested this locally, and this resolves the issue.

NOTE: I did not implement a fix for the `promise` based API, as I was not sure what you all wanted to do in terms of extending the `types/index.d.ts`.