### PR TITLE
Remove static target import

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,11 +3,6 @@
 const { load, currentTarget } = require("@neon-rs/load");
 const { familySync, GLIBC } = require("detect-libc");
 
-// Static requires for bundlers.
-if (0) {
-  require("./.targets");
-}
-
 function requireNative() {
   if (process.env.LIBSQL_JS_DEV) {
     return load(__dirname)


### PR DESCRIPTION
This PR removes static target imports.

[There was a user](https://discord.com/channels/933071162680958986/1226587290260865194/1226587290260865194) having issues with this part of the code so we are removing to fix it.