### PR TITLE
Fix Statement.run() for SELECT statements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,8 +722,8 @@ dependencies = [
 
 [[package]]
 name = "libsql"
-version = "0.4.0"
-source = "git+https://github.com/tursodatabase/libsql/?rev=8521f874f67365fc07f0469681f3351d65f3c761#8521f874f67365fc07f0469681f3351d65f3c761"
+version = "0.5.0-alpha.1"
+source = "git+https://github.com/tursodatabase/libsql/?rev=dd548a902b56cc5b9daa3cec7a43ca887ea81136#dd548a902b56cc5b9daa3cec7a43ca887ea81136"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -760,7 +760,7 @@ dependencies = [
 [[package]]
 name = "libsql-ffi"
 version = "0.3.0"
-source = "git+https://github.com/tursodatabase/libsql/?rev=8521f874f67365fc07f0469681f3351d65f3c761#8521f874f67365fc07f0469681f3351d65f3c761"
+source = "git+https://github.com/tursodatabase/libsql/?rev=dd548a902b56cc5b9daa3cec7a43ca887ea81136#dd548a902b56cc5b9daa3cec7a43ca887ea81136"
 dependencies = [
  "bindgen",
  "cc",
@@ -769,7 +769,7 @@ dependencies = [
 [[package]]
 name = "libsql-hrana"
 version = "0.2.0"
-source = "git+https://github.com/tursodatabase/libsql/?rev=8521f874f67365fc07f0469681f3351d65f3c761#8521f874f67365fc07f0469681f3351d65f3c761"
+source = "git+https://github.com/tursodatabase/libsql/?rev=dd548a902b56cc5b9daa3cec7a43ca887ea81136#dd548a902b56cc5b9daa3cec7a43ca887ea81136"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -792,7 +792,7 @@ dependencies = [
 [[package]]
 name = "libsql-rusqlite"
 version = "0.31.0"
-source = "git+https://github.com/tursodatabase/libsql/?rev=8521f874f67365fc07f0469681f3351d65f3c761#8521f874f67365fc07f0469681f3351d65f3c761"
+source = "git+https://github.com/tursodatabase/libsql/?rev=dd548a902b56cc5b9daa3cec7a43ca887ea81136#dd548a902b56cc5b9daa3cec7a43ca887ea81136"
 dependencies = [
  "bitflags 2.4.2",
  "fallible-iterator 0.2.0",
@@ -805,7 +805,7 @@ dependencies = [
 [[package]]
 name = "libsql-sqlite3-parser"
 version = "0.12.0"
-source = "git+https://github.com/tursodatabase/libsql/?rev=8521f874f67365fc07f0469681f3351d65f3c761#8521f874f67365fc07f0469681f3351d65f3c761"
+source = "git+https://github.com/tursodatabase/libsql/?rev=dd548a902b56cc5b9daa3cec7a43ca887ea81136#dd548a902b56cc5b9daa3cec7a43ca887ea81136"
 dependencies = [
  "bitflags 2.4.2",
  "cc",
@@ -823,7 +823,7 @@ dependencies = [
 [[package]]
 name = "libsql-sys"
 version = "0.6.0"
-source = "git+https://github.com/tursodatabase/libsql/?rev=8521f874f67365fc07f0469681f3351d65f3c761#8521f874f67365fc07f0469681f3351d65f3c761"
+source = "git+https://github.com/tursodatabase/libsql/?rev=dd548a902b56cc5b9daa3cec7a43ca887ea81136#dd548a902b56cc5b9daa3cec7a43ca887ea81136"
 dependencies = [
  "bytes",
  "libsql-ffi",
@@ -836,7 +836,7 @@ dependencies = [
 [[package]]
 name = "libsql_replication"
 version = "0.4.0"
-source = "git+https://github.com/tursodatabase/libsql/?rev=8521f874f67365fc07f0469681f3351d65f3c761#8521f874f67365fc07f0469681f3351d65f3c761"
+source = "git+https://github.com/tursodatabase/libsql/?rev=dd548a902b56cc5b9daa3cec7a43ca887ea81136#dd548a902b56cc5b9daa3cec7a43ca887ea81136"
 dependencies = [
  "aes",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-libsql = { git = "https://github.com/tursodatabase/libsql/", rev = "8521f874f67365fc07f0469681f3351d65f3c761", features = ["encryption"] }
+libsql = { git = "https://github.com/tursodatabase/libsql/", rev = "dd548a902b56cc5b9daa3cec7a43ca887ea81136", features = ["encryption"] }
 tracing = "0.1"
 once_cell = "1.18.0"
 tokio = { version = "1.29.1", features = [ "rt-multi-thread" ] }

--- a/integration-tests/tests/sync.test.js
+++ b/integration-tests/tests/sync.test.js
@@ -41,6 +41,14 @@ test.serial("Statement.prepare() error", async (t) => {
   });
 });
 
+test.serial("Statement.run() returning rows", async (t) => {
+  const db = t.context.db;
+
+  const stmt = db.prepare("SELECT 1");
+  const info = stmt.run();
+  t.is(info.changes, 0);
+});
+
 test.serial("Statement.run() [positional]", async (t) => {
   const db = t.context.db;
 


### PR DESCRIPTION
The `better-sqlite3` API allows `run()` on all types of statements. However, we currently use `libsql` crate's `Statement::execute()`, which returns an error if a statement results in rows. Fix the compatibility issue by switching to the new `Statement::run()` method in `libsql`.