### PR TITLE
Export `/promise` types in package.json#exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,10 @@
       "types": "./types/index.d.ts",
       "default": "./index.js"
     },
-    "./promise": "./promise.js"
+    "./promise": {
+      "types": "./types/promise.d.ts",
+      "default": "./promise.js"
+    }
   },
   "scripts": {
     "test": "cargo test",


### PR DESCRIPTION
Following up on https://github.com/tursodatabase/libsql-js/pull/119, this PR proposes that we expose the newer `/types/promise.d.ts` file through the `package.json#exports` field, the same way the synchronous interface is exposed.