### PR TITLE
Support Linux ARM

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,3 +2,5 @@
 rustflags = ["-C", "target-feature=-crt-static"]
 [target.aarch64-unknown-linux-musl]
 rustflags = ["-C", "target-feature=-crt-static"]
+[target.arm-unknown-linux-musleabihf]
+rustflags = ["-C", "target-feature=-crt-static"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl, aarch64-unknown-linux-gnu, aarch64-unknown-linux-musl, arm-unknown-linux-gnueabihf]
+        target: [x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl, aarch64-unknown-linux-gnu, aarch64-unknown-linux-musl, arm-unknown-linux-gnueabihf, arm-unknown-linux-musleabihf]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl, aarch64-unknown-linux-gnu, aarch64-unknown-linux-musl]
+        target: [x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl, aarch64-unknown-linux-gnu, aarch64-unknown-linux-musl, arm-unknown-linux-gnueabihf]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,7 +84,7 @@ jobs:
     name: Builds (other platforms)
     strategy:
       matrix:
-        target: [x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl, aarch64-unknown-linux-gnu, aarch64-unknown-linux-musl]
+        target: [x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl, aarch64-unknown-linux-gnu, aarch64-unknown-linux-musl, arm-unknown-linux-gnueabihf, arm-unknown-linux-musleabihf]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const { load, currentTarget } = require("@neon-rs/load");
-const { familySync, GLIBC } = require("detect-libc");
+const { familySync, GLIBC, MUSL } = require("detect-libc");
 
 function requireNative() {
   if (process.env.LIBSQL_JS_DEV) {
@@ -11,13 +11,17 @@ function requireNative() {
   // Workaround for Bun, which reports a musl target, but really wants glibc...
   if (familySync() == GLIBC) {
     switch (target) {
-    case "linux-x64-musl":
-      target = "linux-x64-gnu";
-      break;
-    case "linux-arm64-musl":
-      target = "linux-arm64-gnu";
-      break;
+      case "linux-x64-musl":
+        target = "linux-x64-gnu";
+        break;
+      case "linux-arm64-musl":
+        target = "linux-arm64-gnu";
+        break;
     }
+  }
+  // @neon-rs/load doesn't detect arm musl
+  if (target === "linux-arm-gnueabihf" && familySync() == MUSL) {
+      target = "linux-arm-musleabihf";
   }
   return require(`@libsql/${target}`);
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "cpu": [
     "x64",
     "arm64",
-    "wasm32"
+    "wasm32",
+    "arm"
   ],
   "main": "index.js",
   "types": "types/index.d.ts",
@@ -50,7 +51,9 @@
       "x86_64-apple-darwin": "@libsql/darwin-x64",
       "x86_64-pc-windows-msvc": "@libsql/win32-x64-msvc",
       "x86_64-unknown-linux-gnu": "@libsql/linux-x64-gnu",
-      "x86_64-unknown-linux-musl": "@libsql/linux-x64-musl"
+      "x86_64-unknown-linux-musl": "@libsql/linux-x64-musl",
+      "arm-unknown-linux-gnueabihf": "@libsql/linux-arm-gnueabihf",
+      "arm-unknown-linux-musleabihf": "@libsql/linux-arm-musleabihf"
     }
   },
   "repository": {

--- a/promise.js
+++ b/promise.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const { load, currentTarget } = require("@neon-rs/load");
-const { familySync, GLIBC } = require("detect-libc");
+const { familySync, GLIBC, MUSL } = require("detect-libc");
 
 // Static requires for bundlers.
 if (0) {

--- a/promise.js
+++ b/promise.js
@@ -25,13 +25,17 @@ function requireNative() {
   // Workaround for Bun, which reports a musl target, but really wants glibc...
   if (familySync() == GLIBC) {
     switch (target) {
-    case "linux-x64-musl":
-      target = "linux-x64-gnu";
-      break;
-    case "linux-arm64-musl":
-      target = "linux-arm64-gnu";
-      break;
-    }
+      case "linux-x64-musl":
+        target = "linux-x64-gnu";
+        break;
+      case "linux-arm64-musl":
+        target = "linux-arm64-gnu";
+        break;
+      }
+  }
+  // @neon-rs/load doesn't detect arm musl
+  if (target === "linux-arm-gnueabihf" && familySync() == MUSL) {
+      target = "linux-arm-musleabihf";
   }
   return require(`@libsql/${target}`);
 }


### PR DESCRIPTION
Add support for `arm-unknown-linux-gnueabihf`

Fix build by using https://github.com/tursodatabase/libsql/commit/2a8507dd5e8b9e0622c7bf82d42a01d4b3c42ad1 instead of https://github.com/tursodatabase/libsql/commit/9aa89fee3a096538336d30f3d9e9f2df8ba6677d

Closes #163 