### PR TITLE
feat: switch to armv7

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,5 +2,5 @@
 rustflags = ["-C", "target-feature=-crt-static"]
 [target.aarch64-unknown-linux-musl]
 rustflags = ["-C", "target-feature=-crt-static"]
-[target.arm-unknown-linux-musleabihf]
+[target.armv7-unknown-linux-musleabihf]
 rustflags = ["-C", "target-feature=-crt-static"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl, aarch64-unknown-linux-gnu, aarch64-unknown-linux-musl, arm-unknown-linux-gnueabihf, arm-unknown-linux-musleabihf]
+        target: [x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl, aarch64-unknown-linux-gnu, aarch64-unknown-linux-musl, armv7-unknown-linux-gnueabihf, armv7-unknown-linux-musleabihf]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,7 +84,7 @@ jobs:
     name: Builds (other platforms)
     strategy:
       matrix:
-        target: [x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl, aarch64-unknown-linux-gnu, aarch64-unknown-linux-musl, arm-unknown-linux-gnueabihf, arm-unknown-linux-musleabihf]
+        target: [x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl, aarch64-unknown-linux-gnu, aarch64-unknown-linux-musl, armv7-unknown-linux-gnueabihf, armv7-unknown-linux-musleabihf]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/index.js
+++ b/index.js
@@ -20,8 +20,10 @@ function requireNative() {
     }
   }
   // @neon-rs/load doesn't detect arm musl
-  if (target === "linux-arm-gnueabihf" && familySync() == MUSL) {
+  if (familySync() == MUSL) {
+    if (target === "linux-arm-gnueabihf") {
       target = "linux-arm-musleabihf";
+    }
   }
   return require(`@libsql/${target}`);
 }

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
       "x86_64-pc-windows-msvc": "@libsql/win32-x64-msvc",
       "x86_64-unknown-linux-gnu": "@libsql/linux-x64-gnu",
       "x86_64-unknown-linux-musl": "@libsql/linux-x64-musl",
-      "arm-unknown-linux-gnueabihf": "@libsql/linux-arm-gnueabihf",
-      "arm-unknown-linux-musleabihf": "@libsql/linux-arm-musleabihf"
+      "armv7-unknown-linux-gnueabihf": "@libsql/linux-arm-gnueabihf",
+      "armv7-unknown-linux-musleabihf": "@libsql/linux-arm-musleabihf"
     }
   },
   "repository": {

--- a/promise.js
+++ b/promise.js
@@ -35,8 +35,10 @@ function requireNative() {
       }
   }
   // @neon-rs/load doesn't detect arm musl
-  if (target === "linux-arm-gnueabihf" && familySync() == MUSL) {
+  if (familySync() == MUSL) {
+    if (target === "linux-arm-gnueabihf") {
       target = "linux-arm-musleabihf";
+    }
   }
   return require(`@libsql/${target}`);
 }


### PR DESCRIPTION
## Motivation 

Node dropped support for armv6 since Node 12 [^1]

most devices run on armv7. only some very old raspberry pis.

many repos only build for armv7.

## Changes

this pr keeps the old package name, which could create ambiguity.

it also reformats the target override logic, to match the bun workaround

## Notes

PR #186 would break, even tho I think its a good solution.

But it seems that #182 already hardcodes the import strings (which would make #186 obsolete) but development has stopped

[^1]: https://github.com/nodejs/node/blob/main/BUILDING.md#platform-list