### PR TITLE
Avoid dynamic require of the native package

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,33 @@ function requireNative() {
   if (target === "linux-arm-gnueabihf" && familySync() == MUSL) {
       target = "linux-arm-musleabihf";
   }
-  return require(`@libsql/${target}`);
+
+  // JS bundlers (webpack, turbopack, rspack, rollup, etc.) use basic static
+  // analysis to determine what paths to include. `target` is not trivially
+  // determinable, so write this code in a way that is. Otherwise we may include
+  // all of `@libsql/*`, which can include other unintended packages/files.
+  switch (target) {
+    case "darwin-arm64":
+      return require("@libsql/darwin-arm64");
+    case "linux-arm64-gnu":
+      return require("@libsql/linux-arm64-gnu");
+    case "linux-arm64-musl":
+      return require("@libsql/linux-arm64-musl");
+    case "darwin-x64":
+      return require("@libsql/darwin-x64");
+    case "win32-x64-msvc":
+      return require("@libsql/win32-x64-msvc");
+    case "linux-x64-gnu":
+      return require("@libsql/linux-x64-gnu");
+    case "linux-x64-musl":
+      return require("@libsql/linux-x64-musl");
+    case "linux-arm-gnueabihf":
+      return require("@libsql/linux-arm-gnueabihf");
+    case "linux-arm-musleabihf":
+      return require("@libsql/linux-arm-musleabihf");
+    default:
+      throw new Error(`unsupported platform: ${target}`);
+  }
 }
 
 const {


### PR DESCRIPTION
Fixes libsql with `next build --turbopack`: https://github.com/vercel/next.js/issues/82881#issuecomment-3215277221

When combined with a non-isolating hoisting package manager (e.g. pnpm avoids this problem), these requires are written in a way that bundlers may be forced to pull in extra packages and files that are also under the `@libsql/` namespace. Even if this doesn't cause issues with certain tooling, it's playing with fire.

This could be written in a more clever way, but this writes it in the simplest-to-analyze possible way that should work with all bundlers. There's no real standard for what is or isn't statically analyzable by a bundler.

**v0.6.x does not appear to have this problem,** as it's written in a similar way to this, where there are simple `require()` expressions with static strings.