### PR TITLE
Fix race condition in query timeouts

### DIFF
--- a/integration-tests/tests/async.test.js
+++ b/integration-tests/tests/async.test.js
@@ -416,6 +416,29 @@ test.serial("Query timeout option interrupts long-running query", async (t) => {
   db.close();
 });
 
+test.serial("Query timeout option interrupts long-running Statement.get()", async (t) => {
+  const [db, errorType] = await connect(":memory:", { defaultQueryTimeout: 100 });
+  const stmt = await db.prepare(`
+    WITH RECURSIVE numbers(value) AS (
+      SELECT 1
+      UNION ALL
+      SELECT value + 1 FROM numbers WHERE value < 1000000000
+    )
+    SELECT sum(value) FROM numbers;
+  `);
+
+  const error = await t.throwsAsync(async () => {
+    await stmt.get();
+  });
+  t.truthy(error);
+  t.true(error instanceof Error);
+  t.true(error instanceof errorType);
+  t.true(error.message.toLowerCase().includes("interrupt"));
+  t.is(error.code, "SQLITE_INTERRUPT");
+
+  db.close();
+});
+
 test.serial("Query timeout option allows short-running query", async (t) => {
   const [db] = await connect(":memory:", { defaultQueryTimeout: 100 });
   const stmt = await db.prepare("SELECT 1 AS value");
@@ -460,6 +483,57 @@ test.serial("Per-query timeout option interrupts long-running Statement.all()", 
     message: "interrupted",
     code: "SQLITE_INTERRUPT",
   });
+
+  db.close();
+});
+
+test.serial("Per-query timeout option interrupts long-running Statement.get()", async (t) => {
+  const [db, errorType] = await connect(":memory:");
+  const stmt = await db.prepare(`
+    WITH RECURSIVE numbers(value) AS (
+      SELECT 1
+      UNION ALL
+      SELECT value + 1 FROM numbers WHERE value < 1000000000
+    )
+    SELECT sum(value) FROM numbers;
+  `);
+
+  const error = await t.throwsAsync(async () => {
+    await stmt.get(undefined, { queryTimeout: 100 });
+  });
+  t.truthy(error);
+  t.true(error instanceof Error);
+  t.true(error instanceof errorType);
+  t.true(error.message.toLowerCase().includes("interrupt"));
+  t.is(error.code, "SQLITE_INTERRUPT");
+
+  db.close();
+});
+
+test.serial("Timeout on Statement.get() does not leak into later prepare()/EXPLAIN", async (t) => {
+  t.timeout(30_000);
+  const [db, errorType] = await connect(":memory:");
+  const longRunningStmt = await db.prepare(`
+    WITH RECURSIVE numbers(value) AS (
+      SELECT 1
+      UNION ALL
+      SELECT value + 1 FROM numbers WHERE value < 1000000000
+    )
+    SELECT sum(value) FROM numbers;
+  `);
+
+  for (let i = 0; i < 20; i++) {
+    const error = await t.throwsAsync(async () => {
+      await longRunningStmt.get(undefined, { queryTimeout: 50 });
+    });
+    t.truthy(error);
+    t.true(error instanceof errorType);
+    t.true(error.message.toLowerCase().includes("interrupt"));
+
+    const explainStmt = await db.prepare("EXPLAIN QUERY PLAN SELECT 1");
+    const explainRows = await explainStmt.all();
+    t.true(explainRows.length > 0);
+  }
 
   db.close();
 });

--- a/integration-tests/tests/sync.test.js
+++ b/integration-tests/tests/sync.test.js
@@ -479,6 +479,34 @@ test.serial("Query timeout option interrupts long-running query", async (t) => {
   db.close();
 });
 
+test.serial("Query timeout option interrupts long-running Statement.get()", async (t) => {
+  if (t.context.provider === "sqlite") {
+    t.assert(true);
+    return;
+  }
+
+  const [db, errorType] = await connect(":memory:", { defaultQueryTimeout: 100 });
+  const stmt = db.prepare(`
+    WITH RECURSIVE numbers(value) AS (
+      SELECT 1
+      UNION ALL
+      SELECT value + 1 FROM numbers WHERE value < 1000000000
+    )
+    SELECT sum(value) FROM numbers;
+  `);
+
+  const error = t.throws(() => {
+    stmt.get();
+  });
+  t.truthy(error);
+  t.true(error instanceof Error);
+  t.true(error instanceof errorType);
+  t.true(error.message.toLowerCase().includes("interrupt"));
+  t.is(error.code, "SQLITE_INTERRUPT");
+
+  db.close();
+});
+
 test.serial("Query timeout option allows short-running query", async (t) => {
   if (t.context.provider === "sqlite") {
     t.assert(true);
@@ -509,6 +537,67 @@ test.serial("Per-query timeout option interrupts long-running Statement.all()", 
     message: "interrupted",
     code: "SQLITE_INTERRUPT",
   });
+
+  db.close();
+});
+
+test.serial("Per-query timeout option interrupts long-running Statement.get()", async (t) => {
+  if (t.context.provider === "sqlite") {
+    t.assert(true);
+    return;
+  }
+
+  const [db, errorType] = await connect(":memory:");
+  const stmt = db.prepare(`
+    WITH RECURSIVE numbers(value) AS (
+      SELECT 1
+      UNION ALL
+      SELECT value + 1 FROM numbers WHERE value < 1000000000
+    )
+    SELECT sum(value) FROM numbers;
+  `);
+
+  const error = t.throws(() => {
+    stmt.get(undefined, { queryTimeout: 100 });
+  });
+  t.truthy(error);
+  t.true(error instanceof Error);
+  t.true(error instanceof errorType);
+  t.true(error.message.toLowerCase().includes("interrupt"));
+  t.is(error.code, "SQLITE_INTERRUPT");
+
+  db.close();
+});
+
+test.serial("Timeout on Statement.get() does not leak into later prepare()/EXPLAIN", async (t) => {
+  if (t.context.provider === "sqlite") {
+    t.assert(true);
+    return;
+  }
+
+  t.timeout(30_000);
+  const [db, errorType] = await connect(":memory:");
+  const longRunningStmt = db.prepare(`
+    WITH RECURSIVE numbers(value) AS (
+      SELECT 1
+      UNION ALL
+      SELECT value + 1 FROM numbers WHERE value < 1000000000
+    )
+    SELECT sum(value) FROM numbers;
+  `);
+
+  for (let i = 0; i < 20; i++) {
+    const error = t.throws(() => {
+      longRunningStmt.get(undefined, { queryTimeout: 50 });
+    });
+    t.truthy(error);
+    t.true(error instanceof errorType);
+    t.true(error.message.toLowerCase().includes("interrupt"));
+
+    const explainStmt = db.prepare("EXPLAIN QUERY PLAN SELECT 1");
+    const explainRows = explainStmt.all();
+    t.true(explainRows.length > 0);
+  }
 
   db.close();
 });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ use napi::{
 };
 use napi_derive::napi;
 use once_cell::sync::OnceCell;
-use query_timeout::{QueryTimeoutManager, TimeoutGuard};
+use query_timeout::{QueryTimeoutGuard, QueryTimeoutManager};
 use std::{
     str::FromStr,
     sync::{
@@ -239,6 +239,8 @@ pub struct Database {
     query_timeout: Option<Duration>,
     // Shared timeout manager for efficient query timeout handling.
     timeout_manager: Arc<QueryTimeoutManager>,
+    // Ensures only one operation executes per connection at a time.
+    execution_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl Drop for Database {
@@ -326,7 +328,7 @@ pub async fn connect(path: String, opts: Option<Options>) -> Result<Database> {
         let builder = libsql::Builder::new_local(&path);
         builder.build().await.map_err(Error::from)?
     };
-    let conn = db.connect().map_err(Error::from)?;
+    let conn = Arc::new(db.connect().map_err(Error::from)?);
     let default_safe_integers = AtomicBool::new(false);
     let memory = path == ":memory:";
     let timeout = match opts {
@@ -341,14 +343,16 @@ pub async fn connect(path: String, opts: Option<Options>) -> Result<Database> {
         .as_ref()
         .and_then(|o| o.defaultQueryTimeout)
         .and_then(query_timeout_duration);
-    let timeout_manager = Arc::new(QueryTimeoutManager::new());
+    let timeout_manager = Arc::new(QueryTimeoutManager::new(&conn));
+    let execution_lock = Arc::new(tokio::sync::Mutex::new(()));
     Ok(Database {
         db: Some(db),
-        conn: Some(Arc::new(conn)),
+        conn: Some(conn),
         default_safe_integers,
         memory,
         query_timeout,
         timeout_manager,
+        execution_lock,
     })
 }
 
@@ -404,7 +408,15 @@ impl Database {
                 ));
             }
         };
-        let stmt = { conn.prepare(&sql).await.map_err(Error::from)? };
+        let _execution_guard = self.execution_lock.clone().lock_owned().await;
+        let stmt = match conn.prepare(&sql).await {
+            Ok(stmt) => stmt,
+            Err(err) if is_sqlite_interrupt(&err) => {
+                clear_stale_interrupt(&conn).await;
+                conn.prepare(&sql).await.map_err(Error::from)?
+            }
+            Err(err) => return Err(Error::from(err).into()),
+        };
         let mode = AccessMode {
             safe_ints: self.default_safe_integers.load(Ordering::SeqCst).into(),
             raw: false.into(),
@@ -417,6 +429,7 @@ impl Database {
             mode,
             self.query_timeout,
             self.timeout_manager.clone(),
+            self.execution_lock.clone(),
         ))
     }
 
@@ -559,7 +572,8 @@ impl Database {
             Some(timeout_ms) => query_timeout_duration(timeout_ms),
             None => self.query_timeout,
         };
-        let _guard = query_timeout.map(|t| self.timeout_manager.register(&conn, t));
+        let _execution_guard = self.execution_lock.clone().lock_owned().await;
+        let _timeout_guard = query_timeout.map(|t| self.timeout_manager.register(t));
         conn.execute_batch(&sql).await.map_err(Error::from)?;
         Ok(())
     }
@@ -843,6 +857,25 @@ fn query_timeout_duration(timeout_ms: f64) -> Option<Duration> {
     }
 }
 
+fn is_sqlite_interrupt(err: &libsql::Error) -> bool {
+    matches!(
+        err,
+        libsql::Error::SqliteFailure(raw_code, _) if *raw_code == libsql::ffi::SQLITE_INTERRUPT
+    )
+}
+
+async fn clear_stale_interrupt(conn: &Arc<libsql::Connection>) {
+    // If a timeout interrupt races with operation completion, the next operation
+    // can observe a stale SQLITE_INTERRUPT. Probe the connection to consume it.
+    for _ in 0..3 {
+        match conn.execute_batch("SELECT 1").await {
+            Ok(_) => break,
+            Err(err) if is_sqlite_interrupt(&err) => continue,
+            Err(_) => break,
+        }
+    }
+}
+
 /// SQLite statement object.
 #[napi]
 pub struct Statement {
@@ -858,6 +891,8 @@ pub struct Statement {
     query_timeout: Option<Duration>,
     // Shared timeout manager.
     timeout_manager: Arc<QueryTimeoutManager>,
+    // Shared per-connection execution lock.
+    execution_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 #[napi]
@@ -875,6 +910,7 @@ impl Statement {
         mode: AccessMode,
         query_timeout: Option<Duration>,
         timeout_manager: Arc<QueryTimeoutManager>,
+        execution_lock: Arc<tokio::sync::Mutex<()>>,
     ) -> Self {
         let column_names: Vec<std::ffi::CString> = stmt
             .columns()
@@ -889,6 +925,7 @@ impl Statement {
             mode,
             query_timeout,
             timeout_manager,
+            execution_lock,
         }
     }
 
@@ -910,10 +947,13 @@ impl Statement {
         let start = std::time::Instant::now();
         let stmt = self.stmt.clone();
         let conn = self.conn.clone();
-        let guard = self.start_timeout_guard(query_options);
+        let query_timeout = self.resolve_query_timeout(query_options);
+        let timeout_manager = self.timeout_manager.clone();
+        let execution_lock = self.execution_lock.clone();
 
         let future = async move {
-            let _guard = guard;
+            let _execution_guard = execution_lock.lock_owned().await;
+            let _timeout_guard = query_timeout.map(|t| timeout_manager.register(t));
             stmt.run(params).await.map_err(Error::from)?;
             let changes = if conn.total_changes() == total_changes_before {
                 0
@@ -951,7 +991,6 @@ impl Statement {
         let timed = self.mode.timing.load(Ordering::SeqCst);
 
         let params = map_params(&self.stmt, params)?;
-        let stmt = self.stmt.clone();
         let column_names = self.column_names.clone();
 
         let start = if timed {
@@ -960,14 +999,27 @@ impl Statement {
             None
         };
 
+        let stmt = self.stmt.clone();
         let stmt_fut = stmt.clone();
-        let guard = self.start_timeout_guard(query_options);
+        let query_timeout = self.resolve_query_timeout(query_options);
+        let timeout_manager = self.timeout_manager.clone();
+        let execution_lock = self.execution_lock.clone();
         let future = async move {
-            let _guard = guard;
-            let mut rows = stmt_fut.query(params).await.map_err(Error::from)?;
-            let row = rows.next().await.map_err(Error::from)?;
-            let duration: Option<f64> = start.map(|start| start.elapsed().as_secs_f64());
-            Ok((row, duration))
+            let result: std::result::Result<(Option<libsql::Row>, Option<f64>), Error> = {
+                let _execution_guard = execution_lock.lock_owned().await;
+                let _timeout_guard = query_timeout.map(|t| timeout_manager.register(t));
+                async {
+                    let mut rows = stmt_fut.query(params).await.map_err(Error::from)?;
+                    let row = rows.next().await.map_err(Error::from)?;
+                    let duration: Option<f64> = start.map(|start| start.elapsed().as_secs_f64());
+                    Ok((row, duration))
+                }
+                .await
+            };
+            if result.is_err() {
+                stmt_fut.reset();
+            }
+            result.map_err(napi::Error::from)
         };
 
         env.execute_tokio_future(future, move |&mut env, (row, duration)| {
@@ -1031,23 +1083,33 @@ impl Statement {
         let stmt = self.stmt.clone();
         stmt.reset();
         let params = map_params(&stmt, params).unwrap();
-        let stmt = self.stmt.clone();
-        let guard = self.start_timeout_guard(query_options);
+        let stmt_for_query = self.stmt.clone();
+        let stmt_for_iter = stmt_for_query.clone();
+        let query_timeout = self.resolve_query_timeout(query_options);
+        let timeout_manager = self.timeout_manager.clone();
+        let execution_lock = self.execution_lock.clone();
         let future = async move {
-            let rows = stmt.query(params).await.map_err(Error::from)?;
-            Ok::<_, napi::Error>(rows)
+            let execution_guard = execution_lock.lock_owned().await;
+            let timeout_guard = query_timeout.map(|t| timeout_manager.register(t));
+            let rows = stmt_for_query.query(params).await.map_err(Error::from)?;
+            Ok::<_, napi::Error>((rows, execution_guard, timeout_guard))
         };
         let column_names = self.column_names.clone();
-        env.execute_tokio_future(future, move |&mut _env, result| {
-            Ok(RowsIterator::new(
-                Arc::new(tokio::sync::Mutex::new(result)),
-                column_names,
-                safe_ints,
-                raw,
-                pluck,
-                guard,
-            ))
-        })
+        env.execute_tokio_future(
+            future,
+            move |&mut _env, (result, execution_guard, timeout_guard)| {
+                Ok(RowsIterator::new(
+                    Arc::new(tokio::sync::Mutex::new(result)),
+                    stmt_for_iter,
+                    column_names,
+                    safe_ints,
+                    raw,
+                    pluck,
+                    timeout_guard,
+                    execution_guard,
+                ))
+            },
+        )
     }
 
     #[napi]
@@ -1136,11 +1198,6 @@ impl Statement {
             None => self.query_timeout,
         }
     }
-
-    fn start_timeout_guard(&self, query_options: Option<QueryOptions>) -> Option<TimeoutGuard> {
-        self.resolve_query_timeout(query_options)
-            .map(|t| self.timeout_manager.register(&self.conn, t))
-    }
 }
 
 /// Gets first row from statement in blocking mode.
@@ -1163,24 +1220,39 @@ pub fn statement_get_sync(
     };
 
     let rt = runtime()?;
-    let _guard = stmt.start_timeout_guard(query_options);
-    rt.block_on(async move {
-        let params = map_params(&stmt.stmt, params)?;
-        let mut rows = stmt.stmt.query(params).await.map_err(Error::from)?;
-        let row = rows.next().await.map_err(Error::from)?;
-        let duration: Option<f64> = start.map(|start| start.elapsed().as_secs_f64());
-        let result = Statement::get_internal(
-            &env,
-            &row,
-            &stmt.column_names,
-            safe_ints,
-            raw,
-            pluck,
-            duration,
-        );
-        stmt.stmt.reset();
-        result
-    })
+    let query_timeout = stmt.resolve_query_timeout(query_options);
+    let timeout_manager = stmt.timeout_manager.clone();
+    let execution_lock = stmt.execution_lock.clone();
+    let result: Result<(Option<libsql::Row>, Option<f64>)> = {
+        rt.block_on(async move {
+            let _execution_guard = execution_lock.lock_owned().await;
+            let _timeout_guard = query_timeout.map(|t| timeout_manager.register(t));
+            let params = map_params(&stmt.stmt, params)?;
+            let mut rows = stmt.stmt.query(params).await.map_err(Error::from)?;
+            let row = rows.next().await.map_err(Error::from)?;
+            let duration: Option<f64> = start.map(|start| start.elapsed().as_secs_f64());
+            Ok((row, duration))
+        })
+    };
+    match result {
+        Ok((row, duration)) => {
+            let mapped = Statement::get_internal(
+                &env,
+                &row,
+                &stmt.column_names,
+                safe_ints,
+                raw,
+                pluck,
+                duration,
+            );
+            stmt.stmt.reset();
+            mapped
+        }
+        Err(err) => {
+            stmt.stmt.reset();
+            Err(err)
+        }
+    }
 }
 
 /// Runs a statement in blocking mode.
@@ -1192,8 +1264,12 @@ pub fn statement_run_sync(
 ) -> Result<RunResult> {
     stmt.stmt.reset();
     let rt = runtime()?;
-    let _guard = stmt.start_timeout_guard(query_options);
+    let query_timeout = stmt.resolve_query_timeout(query_options);
+    let timeout_manager = stmt.timeout_manager.clone();
+    let execution_lock = stmt.execution_lock.clone();
     rt.block_on(async move {
+        let _execution_guard = execution_lock.lock_owned().await;
+        let _timeout_guard = query_timeout.map(|t| timeout_manager.register(t));
         let params = map_params(&stmt.stmt, params)?;
         let total_changes_before = stmt.conn.total_changes();
         let start = std::time::Instant::now();
@@ -1225,9 +1301,14 @@ pub fn statement_iterate_sync(
     let safe_ints = stmt.mode.safe_ints.load(Ordering::SeqCst);
     let raw = stmt.mode.raw.load(Ordering::SeqCst);
     let pluck = stmt.mode.pluck.load(Ordering::SeqCst);
-    let guard = stmt.start_timeout_guard(query_options);
+    let query_timeout = stmt.resolve_query_timeout(query_options);
+    let timeout_manager = stmt.timeout_manager.clone();
+    let execution_lock = stmt.execution_lock.clone();
     let inner_stmt = stmt.stmt.clone();
-    let (rows, column_names) = rt.block_on(async move {
+    let iter_stmt = inner_stmt.clone();
+    let (rows, column_names, execution_guard, timeout_guard) = rt.block_on(async move {
+        let execution_guard = execution_lock.lock_owned().await;
+        let timeout_guard = query_timeout.map(|t| timeout_manager.register(t));
         inner_stmt.reset();
         let params = map_params(&inner_stmt, params)?;
         let rows = inner_stmt.query(params).await.map_err(Error::from)?;
@@ -1236,15 +1317,17 @@ pub fn statement_iterate_sync(
             column_names
                 .push(std::ffi::CString::new(rows.column_name(i).unwrap().to_string()).unwrap());
         }
-        Ok::<_, napi::Error>((rows, column_names))
+        Ok::<_, napi::Error>((rows, column_names, execution_guard, timeout_guard))
     })?;
     Ok(RowsIterator::new(
         Arc::new(tokio::sync::Mutex::new(rows)),
+        iter_stmt,
         column_names,
         safe_ints,
         raw,
         pluck,
-        guard,
+        timeout_guard,
+        execution_guard,
     ))
 }
 
@@ -1387,30 +1470,36 @@ fn map_value(value: JsUnknown) -> Result<libsql::Value> {
 #[napi]
 pub struct RowsIterator {
     rows: Arc<tokio::sync::Mutex<libsql::Rows>>,
+    stmt: Arc<libsql::Statement>,
     column_names: Vec<std::ffi::CString>,
     safe_ints: bool,
     raw: bool,
     pluck: bool,
-    timeout_guard: Mutex<Option<TimeoutGuard>>,
+    timeout_guard: Mutex<Option<QueryTimeoutGuard>>,
+    execution_guard: Mutex<Option<tokio::sync::OwnedMutexGuard<()>>>,
 }
 
 #[napi]
 impl RowsIterator {
     pub fn new(
         rows: Arc<tokio::sync::Mutex<libsql::Rows>>,
+        stmt: Arc<libsql::Statement>,
         column_names: Vec<std::ffi::CString>,
         safe_ints: bool,
         raw: bool,
         pluck: bool,
-        timeout_guard: Option<TimeoutGuard>,
+        timeout_guard: Option<QueryTimeoutGuard>,
+        execution_guard: tokio::sync::OwnedMutexGuard<()>,
     ) -> Self {
         Self {
             rows,
+            stmt,
             column_names,
             safe_ints,
             raw,
             pluck,
             timeout_guard: Mutex::new(timeout_guard),
+            execution_guard: Mutex::new(Some(execution_guard)),
         }
     }
 
@@ -1420,12 +1509,12 @@ impl RowsIterator {
         let row = match rows.next().await {
             Ok(row) => row,
             Err(err) => {
-                self.release_timeout_guard();
+                self.release_operation_resources();
                 return Err(Error::from(err).into());
             }
         };
         if row.is_none() {
-            self.release_timeout_guard();
+            self.release_operation_resources();
         }
         Ok(Record {
             row,
@@ -1438,12 +1527,15 @@ impl RowsIterator {
 
     #[napi]
     pub fn close(&self) {
-        self.release_timeout_guard();
+        self.release_operation_resources();
     }
 
-    fn release_timeout_guard(&self) {
-        let mut guard = self.timeout_guard.lock().unwrap();
-        guard.take();
+    fn release_operation_resources(&self) {
+        self.stmt.reset();
+        let mut timeout_guard = self.timeout_guard.lock().unwrap();
+        timeout_guard.take();
+        let mut execution_guard = self.execution_guard.lock().unwrap();
+        execution_guard.take();
     }
 }
 

--- a/src/query_timeout.rs
+++ b/src/query_timeout.rs
@@ -1,41 +1,34 @@
 use std::{
     cmp::Reverse,
     collections::BinaryHeap,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc, Mutex, Weak,
-    },
-    time::Duration,
+    sync::{Arc, Condvar, Mutex, Weak},
+    time::{Duration, Instant},
 };
-use tokio::{sync::Notify, time::Instant};
 
-/// A single-background-task timer wheel that interrupts connections when their
-/// query deadline expires. Registering a query returns a [`TimeoutGuard`] —
-/// dropping the guard cancels the timeout.
+/// A single background thread with a timer wheel that interrupts a connection
+/// when the currently registered operation exceeds its deadline.
 pub struct QueryTimeoutManager {
     inner: Arc<Inner>,
 }
 
 struct Inner {
-    entries: Mutex<Entries>,
-    /// Wakes the background task when the earliest deadline changes.
-    notify: Arc<Notify>,
-    /// Set to `true` to make the background task exit.
-    shutdown: AtomicBool,
+    state: Mutex<State>,
+    cv: Condvar,
+    /// Connection to interrupt on timeout.
+    conn: Weak<libsql::Connection>,
 }
 
-struct Entries {
+struct State {
     heap: BinaryHeap<Reverse<Entry>>,
+    current_operation_id: Option<u64>,
     next_id: u64,
+    shutdown: bool,
 }
 
 #[derive(Clone)]
 struct Entry {
     id: u64,
     deadline: Instant,
-    conn: Weak<libsql::Connection>,
-    /// Cleared when the guard is dropped (query finished in time).
-    active: Arc<AtomicBool>,
 }
 
 impl PartialEq for Entry {
@@ -43,12 +36,15 @@ impl PartialEq for Entry {
         self.deadline == other.deadline && self.id == other.id
     }
 }
+
 impl Eq for Entry {}
+
 impl PartialOrd for Entry {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
+
 impl Ord for Entry {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.deadline
@@ -58,122 +54,140 @@ impl Ord for Entry {
 }
 
 impl QueryTimeoutManager {
-    pub fn new() -> Self {
+    pub fn new(conn: &Arc<libsql::Connection>) -> Self {
         let inner = Arc::new(Inner {
-            entries: Mutex::new(Entries {
+            state: Mutex::new(State {
                 heap: BinaryHeap::new(),
+                current_operation_id: None,
                 next_id: 0,
+                shutdown: false,
             }),
-            notify: Arc::new(Notify::new()),
-            shutdown: AtomicBool::new(false),
+            cv: Condvar::new(),
+            conn: Arc::downgrade(conn),
         });
+
         let bg = Arc::downgrade(&inner);
-        tokio::spawn(async move {
-            Self::background_task(bg).await;
+        std::thread::spawn(move || {
+            Self::background_thread(bg);
         });
+
         Self { inner }
     }
 
-    /// Synchronously remove all entries from the heap, releasing any
-    /// connection references the background task is holding.
-    pub fn clear(&self) {
-        let mut entries = self.inner.entries.lock().unwrap();
-        entries.heap.clear();
-    }
-
-    /// Signal the background task to exit and clear all entries.
+    /// Signal the background thread to exit and clear all entries.
     pub fn shutdown(&self) {
-        self.inner.shutdown.store(true, Ordering::Relaxed);
-        self.clear();
-        self.inner.notify.notify_one();
+        {
+            let mut state = self.inner.state.lock().unwrap();
+            state.shutdown = true;
+            state.heap.clear();
+            state.current_operation_id = None;
+        }
+        self.inner.cv.notify_one();
     }
 
-    /// Register a query. The returned guard must be held for the duration of
-    /// the query — dropping it cancels the timeout.
-    pub fn register(&self, conn: &Arc<libsql::Connection>, timeout: Duration) -> TimeoutGuard {
-        let active = Arc::new(AtomicBool::new(true));
-        let mut entries = self.inner.entries.lock().unwrap();
-        let id = entries.next_id;
-        entries.next_id += 1;
+    /// Register a timeout for the currently executing operation.
+    pub fn register(&self, timeout: Duration) -> QueryTimeoutGuard {
+        let mut state = self.inner.state.lock().unwrap();
+
+        let id = state.next_id;
+        state.next_id += 1;
+
+        debug_assert!(
+            state.current_operation_id.is_none(),
+            "only one operation may be active per connection"
+        );
+
         let deadline = Instant::now()
             .checked_add(timeout)
             .unwrap_or_else(|| Instant::now() + Duration::from_secs(86400));
-        let entry = Entry {
-            id,
-            deadline,
-            conn: Arc::downgrade(conn),
-            active: active.clone(),
-        };
-        let is_new_earliest = entries
+        let entry = Entry { id, deadline };
+
+        let is_new_earliest = state
             .heap
             .peek()
-            .map_or(true, |Reverse(e)| entry.deadline < e.deadline);
-        entries.heap.push(Reverse(entry));
-        drop(entries);
+            .map_or(true, |Reverse(existing)| entry.deadline < existing.deadline);
+
+        state.current_operation_id = Some(id);
+        state.heap.push(Reverse(entry));
+        drop(state);
+
         if is_new_earliest {
-            self.inner.notify.notify_one();
+            self.inner.cv.notify_one();
         }
-        TimeoutGuard {
-            active,
-            notify: self.inner.notify.clone(),
+
+        QueryTimeoutGuard {
+            op_id: id,
+            inner: self.inner.clone(),
         }
     }
 
-    async fn background_task(weak: Weak<Inner>) {
+    fn deregister(inner: &Arc<Inner>, op_id: u64) {
+        let mut state = inner.state.lock().unwrap();
+        if state.current_operation_id == Some(op_id) {
+            state.current_operation_id = None;
+        }
+    }
+
+    fn process_expired_deadlines(inner: &Arc<Inner>, state: &mut State) {
+        let mut should_interrupt = false;
+        let now = Instant::now();
+
+        while let Some(Reverse(entry)) = state.heap.peek() {
+            if entry.deadline > now {
+                break;
+            }
+
+            let entry = state
+                .heap
+                .pop()
+                .expect("heap peek succeeded but pop failed")
+                .0;
+
+            if state.current_operation_id == Some(entry.id) {
+                should_interrupt = true;
+            }
+        }
+
+        if should_interrupt {
+            if let Some(conn) = inner.conn.upgrade() {
+                let _ = conn.interrupt();
+            }
+        }
+    }
+
+    fn background_thread(weak: Weak<Inner>) {
         loop {
             let inner = match weak.upgrade() {
                 Some(inner) => inner,
-                None => return, // Manager dropped — exit.
+                None => return,
             };
 
-            if inner.shutdown.load(Ordering::Relaxed) {
-                return;
-            }
+            let mut state = inner.state.lock().unwrap();
 
-            // Find the next deadline, skipping cancelled entries.
-            let next = {
-                let mut entries = inner.entries.lock().unwrap();
-                loop {
-                    match entries.heap.peek() {
-                        Some(Reverse(e)) if !e.active.load(Ordering::Relaxed) => {
-                            entries.heap.pop();
-                        }
-                        Some(Reverse(e)) => break Some(e.clone()),
-                        None => break None,
-                    }
+            loop {
+                if state.shutdown {
+                    return;
                 }
-            };
 
-            match next {
-                Some(entry) => {
-                    tokio::select! {
-                        _ = tokio::time::sleep_until(entry.deadline) => {
-                            // Deadline reached — interrupt if still active.
-                            if entry.active.load(Ordering::Relaxed) {
-                                if let Some(conn) = entry.conn.upgrade() {
-                                    let _ = conn.interrupt();
-                                }
-                            }
-                            // Remove this entry.
-                            let mut entries = inner.entries.lock().unwrap();
-                            // Pop entries that are done (expired or cancelled).
-                            while let Some(Reverse(e)) = entries.heap.peek() {
-                                if !e.active.load(Ordering::Relaxed) || e.id == entry.id {
-                                    entries.heap.pop();
-                                } else {
-                                    break;
-                                }
+                match state.heap.peek().map(|Reverse(entry)| entry.deadline) {
+                    Some(deadline) => {
+                        let now = Instant::now();
+                        if deadline > now {
+                            let wait_for = deadline.saturating_duration_since(now);
+                            let (new_state, timeout_result) =
+                                inner.cv.wait_timeout(state, wait_for).unwrap();
+                            state = new_state;
+
+                            if !timeout_result.timed_out() {
+                                continue;
                             }
                         }
-                        _ = inner.notify.notified() => {
-                            // A new earlier deadline was added; re-check.
-                        }
+
+                        Self::process_expired_deadlines(&inner, &mut state);
                     }
-                }
-                None => {
-                    // Nothing to do — wait until a new entry is registered.
-                    // Must hold the Arc while waiting so we can detect drop next iteration.
-                    inner.notify.notified().await;
+                    None => {
+                        state = inner.cv.wait(state).unwrap();
+                    }
                 }
             }
         }
@@ -182,30 +196,26 @@ impl QueryTimeoutManager {
 
 impl Drop for QueryTimeoutManager {
     fn drop(&mut self) {
-        // Signal the background task to exit.
-        self.inner.shutdown.store(true, Ordering::Relaxed);
-        self.inner.notify.notify_one();
+        self.shutdown();
     }
 }
 
-/// Dropping this guard cancels the associated query timeout.
-pub struct TimeoutGuard {
-    active: Arc<AtomicBool>,
-    notify: Arc<Notify>,
+/// RAII handle for a registered timeout.
+pub struct QueryTimeoutGuard {
+    op_id: u64,
+    inner: Arc<Inner>,
 }
 
-impl Drop for TimeoutGuard {
+impl Drop for QueryTimeoutGuard {
     fn drop(&mut self) {
-        self.active.store(false, Ordering::Relaxed);
-        // Wake the background task so it can clean up the cancelled entry.
-        self.notify.notify_one();
+        QueryTimeoutManager::deregister(&self.inner, self.op_id);
+        self.inner.cv.notify_one();
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
 
     async fn test_conn() -> Arc<libsql::Connection> {
         let db = libsql::Builder::new_local(":memory:")
@@ -219,10 +229,10 @@ mod tests {
     #[ntest::timeout(10000)]
     async fn deadline_expires_interrupts_connection() {
         let conn = test_conn().await;
-        let mgr = QueryTimeoutManager::new();
+        let mgr = QueryTimeoutManager::new(&conn);
 
-        // Register a 200ms timeout, then start an infinite query.
-        let _guard = mgr.register(&conn, Duration::from_millis(200));
+        let _guard = mgr.register(Duration::from_millis(200));
+
         let fut = {
             let conn = conn.clone();
             tokio::spawn(async move {
@@ -233,7 +243,6 @@ mod tests {
             })
         };
 
-        // The query should have been interrupted by the timeout.
         let result = fut.await.unwrap();
         assert!(result.is_err(), "query should have been interrupted");
     }
@@ -242,17 +251,13 @@ mod tests {
     #[ntest::timeout(10000)]
     async fn guard_dropped_before_deadline_cancels_timeout() {
         let conn = test_conn().await;
-        let mgr = QueryTimeoutManager::new();
+        let mgr = QueryTimeoutManager::new(&conn);
 
-        let guard = mgr.register(&conn, Duration::from_millis(200));
-
-        // Query "finishes" before the deadline.
+        let guard = mgr.register(Duration::from_millis(200));
         drop(guard);
 
-        // Wait past where the deadline would have been.
-        tokio::time::sleep(Duration::from_millis(300)).await;
+        std::thread::sleep(Duration::from_millis(300));
 
-        // Connection should still work — no spurious interrupt.
         let result = conn.execute_batch("SELECT 1").await;
         assert!(
             result.is_ok(),
@@ -262,86 +267,22 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[ntest::timeout(10000)]
-    async fn guard_drop_cleans_entry_from_heap() {
+    async fn stale_deadline_does_not_interrupt_next_operation() {
         let conn = test_conn().await;
-        let mgr = QueryTimeoutManager::new();
+        let mgr = QueryTimeoutManager::new(&conn);
 
-        let guard = mgr.register(&conn, Duration::from_millis(500));
-
+        let guard = mgr.register(Duration::from_millis(200));
         drop(guard);
-        // Let the background task wake up and clean the cancelled entry.
-        tokio::time::sleep(Duration::from_millis(50)).await;
 
-        let entries = mgr.inner.entries.lock().unwrap();
-        assert_eq!(
-            entries.heap.len(),
-            0,
-            "dropping guard should clean up the entry from the heap"
-        );
-    }
+        // Register a second operation after the first one has been deregistered.
+        let _guard2 = mgr.register(Duration::from_millis(5000));
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    #[ntest::timeout(10000)]
-    async fn multiple_deadlines_fire_in_order() {
-        let conn = test_conn().await;
-        let mgr = QueryTimeoutManager::new();
+        std::thread::sleep(Duration::from_millis(300));
 
-        // Register three timeouts at 100ms, 200ms, 300ms.
-        let _g1 = mgr.register(&conn, Duration::from_millis(100));
-        let _g2 = mgr.register(&conn, Duration::from_millis(200));
-        let _g3 = mgr.register(&conn, Duration::from_millis(300));
-
-        // After 150ms, only the first should have fired.
-        tokio::time::sleep(Duration::from_millis(150)).await;
-        {
-            let entries = mgr.inner.entries.lock().unwrap();
-            assert_eq!(entries.heap.len(), 2, "only first entry should have fired");
-        }
-
-        // After 350ms total, all three should have fired.
-        tokio::time::sleep(Duration::from_millis(200)).await;
-        {
-            let entries = mgr.inner.entries.lock().unwrap();
-            assert_eq!(entries.heap.len(), 0, "all entries should be cleaned up");
-        }
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    #[ntest::timeout(10000)]
-    async fn new_earlier_deadline_preempts_existing() {
-        let conn = test_conn().await;
-        let mgr = QueryTimeoutManager::new();
-
-        // Register a long timeout first, then a shorter one that should preempt.
-        let _g1 = mgr.register(&conn, Duration::from_millis(5000));
-        let _g2 = mgr.register(&conn, Duration::from_millis(200));
-
-        let fut = {
-            let conn = conn.clone();
-            tokio::spawn(async move {
-                conn.execute_batch(
-                    "WITH RECURSIVE r(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM r) SELECT * FROM r",
-                )
-                .await
-            })
-        };
-
-        let result = fut.await.unwrap();
+        let result = conn.execute_batch("SELECT 1").await;
         assert!(
-            result.is_err(),
-            "shorter deadline should have interrupted the query"
+            result.is_ok(),
+            "stale timeout entry should not interrupt a different operation"
         );
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    #[ntest::timeout(10000)]
-    async fn background_task_exits_when_manager_dropped() {
-        let conn = test_conn().await;
-        let mgr = QueryTimeoutManager::new();
-        let guard = mgr.register(&conn, Duration::from_millis(5000));
-        drop(guard);
-        drop(mgr);
-        // If the background task didn't exit, it would leak — verify no panic.
-        tokio::time::sleep(Duration::from_millis(50)).await;
     }
 }


### PR DESCRIPTION
The previous fix (0a3d2bd) eagerly released TimeoutGuard when an iterator finished, but a race remained: the background task could peek the heap, see an active entry, and call conn.interrupt() while the query was finishing on another thread. Because SQLite's interrupt flag is connection-scoped, a late-arriving signal would pend on the connection and fire on the next operation — typically a prepare() or EXPLAIN issued right after a timed-out stmt.get(), surfacing as a spurious SQLITE_INTERRUPT.

Fix:

- Make QueryTimeoutManager per-connection (holds Weak<Connection>) and track a single `current_operation_id`. The background thread only interrupts when the expired entry's id matches the currently registered operation; older entries are drained without side effects.
- Serialize operations on a connection with an execution_lock held across prepare(), execute_batch(), and Statement.{get,all,run}. This gives "current operation" a well-defined meaning and closes the race between guard release and interrupt dispatch.
- Defense-in-depth: if prepare() returns SQLITE_INTERRUPT, probe the connection with SELECT 1 (up to three times) to consume any signal that still slipped through before retrying.
- Swap tokio Notify/task + per-entry AtomicBool for std::thread + Condvar. The manager is single-consumer and no longer needs an async runtime.

Tests:

- Statement.get() with both defaultQueryTimeout and per-query queryTimeout options (async + sync).
- Regression test: 20 iterations of timing out stmt.get(..., { queryTimeout: 50 }) and immediately running EXPLAIN QUERY PLAN on the same connection — each EXPLAIN must succeed.