### PR TITLE
Fix async sync error conversion

### DIFF
--- a/integration-tests/tests/async.test.js
+++ b/integration-tests/tests/async.test.js
@@ -340,6 +340,17 @@ test.serial("Database.exec() after close()", async (t) => {
   });
 });
 
+test.serial("Database.sync() after close()", async (t) => {
+  const db = t.context.db;
+  db.close();
+  await t.throwsAsync(async () => {
+    await db.sync();
+  }, {
+    instanceOf: TypeError,
+    message: "The database connection is not open"
+  });
+});
+
 test.serial("Database.interrupt()", async (t) => {
   const db = t.context.db;
   const stmt = await db.prepare("WITH RECURSIVE infinite_loop(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM infinite_loop) SELECT * FROM infinite_loop;");

--- a/promise.js
+++ b/promise.js
@@ -101,9 +101,9 @@ class Database {
     });
   }
 
-  sync() {
+  async sync() {
     try {
-      return this.db.sync();
+      return await this.db.sync();
     } catch (err) {
       throw convertError(err);
     }


### PR DESCRIPTION
## Summary
- make the promise API `sync()` await the native promise so rejected errors go through `convertError`
- add a regression test for `Database.sync()` after `close()` returning the same TypeError as other promise API methods

Fixes #147.

## Verification
- `npm exec tsc`
- `git diff --check`
- `npm test` partially: SQLite provider tests passed; libSQL/native tests could not run in this environment because `cargo` is not installed, so the native `libsql-darwin-arm64` binding could not be built.