### PR TITLE
Use a single global timer wheel for query timeouts

### DIFF
--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -8,6 +8,7 @@
     "test:async": "cross-env LIBSQL_JS_DEV=1 ava tests/async.test.js",
     "test:extensions": "cross-env LIBSQL_JS_DEV=1 ava tests/extensions.test.js",
     "test:concurrency": "ava tests/concurrency.test.js",
+    "test:connections": "cross-env LIBSQL_JS_DEV=1 ava tests/connections.test.js",
     "test": "run-s test:* -cln"
   },
   "devDependencies": {

--- a/integration-tests/tests/connections.test.js
+++ b/integration-tests/tests/connections.test.js
@@ -1,0 +1,69 @@
+import test from "ava";
+import crypto from "crypto";
+import fs from "fs";
+
+// Reproducer for the connection-exhaustion regression reported between
+// 0.6.0-pre.33 (opens 1500 connections cleanly) and 0.6.0-pre.36 (fails
+// around 400 opens). Each test opens a large number of connections to the
+// same on-disk database and keeps them all open at once, then closes them.
+//
+// The count can be overridden with the CONNECTION_COUNT env var.
+const CONNECTION_COUNT = Number(process.env.CONNECTION_COUNT ?? 1500);
+
+test.serial("Open many connections [async]", async (t) => {
+  const libsql = await import("libsql/promise");
+  const path = genDatabaseFilename();
+
+  const connections = [];
+  try {
+    for (let i = 0; i < CONNECTION_COUNT; i++) {
+      const db = await libsql.connect(path);
+      // Touch the connection so we know it is actually usable.
+      await db.exec("SELECT 1");
+      connections.push(db);
+    }
+    t.is(connections.length, CONNECTION_COUNT);
+  } finally {
+    for (const db of connections) {
+      db.close();
+    }
+    cleanup(path);
+  }
+});
+
+test.serial("Open many connections [sync]", async (t) => {
+  const x = await import("libsql");
+  const Database = x.default;
+  const path = genDatabaseFilename();
+
+  const connections = [];
+  try {
+    for (let i = 0; i < CONNECTION_COUNT; i++) {
+      const db = new Database(path);
+      // Touch the connection so we know it is actually usable.
+      db.exec("SELECT 1");
+      connections.push(db);
+    }
+    t.is(connections.length, CONNECTION_COUNT);
+  } finally {
+    for (const db of connections) {
+      db.close();
+    }
+    cleanup(path);
+  }
+});
+
+/// Generate a unique database filename
+const genDatabaseFilename = () => {
+  return `test-${crypto.randomBytes(8).toString("hex")}.db`;
+};
+
+const cleanup = (path) => {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      fs.unlinkSync(path + suffix);
+    } catch {
+      // ignore
+    }
+  }
+};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,15 @@ use napi::{
 use napi_derive::napi;
 use once_cell::sync::OnceCell;
 use query_timeout::{QueryTimeoutGuard, QueryTimeoutManager};
+
+/// Registers a query timeout against the process-wide timer wheel, if one was
+/// requested. Returns a guard that cancels the timeout when dropped.
+fn register_query_timeout(
+    conn: &Arc<libsql::Connection>,
+    query_timeout: Option<Duration>,
+) -> Option<QueryTimeoutGuard> {
+    query_timeout.map(|t| QueryTimeoutManager::global().register(conn, t))
+}
 use std::{
     str::FromStr,
     sync::{
@@ -237,15 +246,12 @@ pub struct Database {
     memory: bool,
     // Maximum time in milliseconds that a query is allowed to run.
     query_timeout: Option<Duration>,
-    // Shared timeout manager for efficient query timeout handling.
-    timeout_manager: Arc<QueryTimeoutManager>,
     // Ensures only one operation executes per connection at a time.
     execution_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl Drop for Database {
     fn drop(&mut self) {
-        self.timeout_manager.shutdown();
         self.conn = None;
         self.db = None;
     }
@@ -343,7 +349,6 @@ pub async fn connect(path: String, opts: Option<Options>) -> Result<Database> {
         .as_ref()
         .and_then(|o| o.defaultQueryTimeout)
         .and_then(query_timeout_duration);
-    let timeout_manager = Arc::new(QueryTimeoutManager::new(&conn));
     let execution_lock = Arc::new(tokio::sync::Mutex::new(()));
     Ok(Database {
         db: Some(db),
@@ -351,7 +356,6 @@ pub async fn connect(path: String, opts: Option<Options>) -> Result<Database> {
         default_safe_integers,
         memory,
         query_timeout,
-        timeout_manager,
         execution_lock,
     })
 }
@@ -428,7 +432,6 @@ impl Database {
             stmt,
             mode,
             self.query_timeout,
-            self.timeout_manager.clone(),
             self.execution_lock.clone(),
         ))
     }
@@ -573,7 +576,7 @@ impl Database {
             None => self.query_timeout,
         };
         let _execution_guard = self.execution_lock.clone().lock_owned().await;
-        let _timeout_guard = query_timeout.map(|t| self.timeout_manager.register(t));
+        let _timeout_guard = register_query_timeout(&conn, query_timeout);
         conn.execute_batch(&sql).await.map_err(Error::from)?;
         Ok(())
     }
@@ -620,7 +623,6 @@ impl Database {
     /// Closes the database connection.
     #[napi]
     pub fn close(&mut self) -> Result<()> {
-        self.timeout_manager.shutdown();
         self.conn = None;
         self.db = None;
         Ok(())
@@ -889,8 +891,6 @@ pub struct Statement {
     mode: AccessMode,
     // Maximum time in milliseconds that a query is allowed to run.
     query_timeout: Option<Duration>,
-    // Shared timeout manager.
-    timeout_manager: Arc<QueryTimeoutManager>,
     // Shared per-connection execution lock.
     execution_lock: Arc<tokio::sync::Mutex<()>>,
 }
@@ -909,7 +909,6 @@ impl Statement {
         stmt: libsql::Statement,
         mode: AccessMode,
         query_timeout: Option<Duration>,
-        timeout_manager: Arc<QueryTimeoutManager>,
         execution_lock: Arc<tokio::sync::Mutex<()>>,
     ) -> Self {
         let column_names: Vec<std::ffi::CString> = stmt
@@ -924,7 +923,6 @@ impl Statement {
             column_names,
             mode,
             query_timeout,
-            timeout_manager,
             execution_lock,
         }
     }
@@ -948,12 +946,11 @@ impl Statement {
         let stmt = self.stmt.clone();
         let conn = self.conn.clone();
         let query_timeout = self.resolve_query_timeout(query_options);
-        let timeout_manager = self.timeout_manager.clone();
         let execution_lock = self.execution_lock.clone();
 
         let future = async move {
             let _execution_guard = execution_lock.lock_owned().await;
-            let _timeout_guard = query_timeout.map(|t| timeout_manager.register(t));
+            let _timeout_guard = register_query_timeout(&conn, query_timeout);
             stmt.run(params).await.map_err(Error::from)?;
             let changes = if conn.total_changes() == total_changes_before {
                 0
@@ -1001,13 +998,13 @@ impl Statement {
 
         let stmt = self.stmt.clone();
         let stmt_fut = stmt.clone();
+        let conn = self.conn.clone();
         let query_timeout = self.resolve_query_timeout(query_options);
-        let timeout_manager = self.timeout_manager.clone();
         let execution_lock = self.execution_lock.clone();
         let future = async move {
             let result: std::result::Result<(Option<libsql::Row>, Option<f64>), Error> = {
                 let _execution_guard = execution_lock.lock_owned().await;
-                let _timeout_guard = query_timeout.map(|t| timeout_manager.register(t));
+                let _timeout_guard = register_query_timeout(&conn, query_timeout);
                 async {
                     let mut rows = stmt_fut.query(params).await.map_err(Error::from)?;
                     let row = rows.next().await.map_err(Error::from)?;
@@ -1085,12 +1082,12 @@ impl Statement {
         let params = map_params(&stmt, params)?;
         let stmt_for_query = self.stmt.clone();
         let stmt_for_iter = stmt_for_query.clone();
+        let conn = self.conn.clone();
         let query_timeout = self.resolve_query_timeout(query_options);
-        let timeout_manager = self.timeout_manager.clone();
         let execution_lock = self.execution_lock.clone();
         let future = async move {
             let execution_guard = execution_lock.lock_owned().await;
-            let timeout_guard = query_timeout.map(|t| timeout_manager.register(t));
+            let timeout_guard = register_query_timeout(&conn, query_timeout);
             let rows = stmt_for_query.query(params).await.map_err(Error::from)?;
             Ok::<_, napi::Error>((rows, execution_guard, timeout_guard))
         };
@@ -1221,12 +1218,11 @@ pub fn statement_get_sync(
 
     let rt = runtime()?;
     let query_timeout = stmt.resolve_query_timeout(query_options);
-    let timeout_manager = stmt.timeout_manager.clone();
     let execution_lock = stmt.execution_lock.clone();
     let result: Result<(Option<libsql::Row>, Option<f64>)> = {
         rt.block_on(async move {
             let _execution_guard = execution_lock.lock_owned().await;
-            let _timeout_guard = query_timeout.map(|t| timeout_manager.register(t));
+            let _timeout_guard = register_query_timeout(&stmt.conn, query_timeout);
             let params = map_params(&stmt.stmt, params)?;
             let mut rows = stmt.stmt.query(params).await.map_err(Error::from)?;
             let row = rows.next().await.map_err(Error::from)?;
@@ -1265,11 +1261,10 @@ pub fn statement_run_sync(
     stmt.stmt.reset();
     let rt = runtime()?;
     let query_timeout = stmt.resolve_query_timeout(query_options);
-    let timeout_manager = stmt.timeout_manager.clone();
     let execution_lock = stmt.execution_lock.clone();
     rt.block_on(async move {
         let _execution_guard = execution_lock.lock_owned().await;
-        let _timeout_guard = query_timeout.map(|t| timeout_manager.register(t));
+        let _timeout_guard = register_query_timeout(&stmt.conn, query_timeout);
         let params = map_params(&stmt.stmt, params)?;
         let total_changes_before = stmt.conn.total_changes();
         let start = std::time::Instant::now();
@@ -1302,13 +1297,13 @@ pub fn statement_iterate_sync(
     let raw = stmt.mode.raw.load(Ordering::SeqCst);
     let pluck = stmt.mode.pluck.load(Ordering::SeqCst);
     let query_timeout = stmt.resolve_query_timeout(query_options);
-    let timeout_manager = stmt.timeout_manager.clone();
+    let conn = stmt.conn.clone();
     let execution_lock = stmt.execution_lock.clone();
     let inner_stmt = stmt.stmt.clone();
     let iter_stmt = inner_stmt.clone();
     let (rows, column_names, execution_guard, timeout_guard) = rt.block_on(async move {
         let execution_guard = execution_lock.lock_owned().await;
-        let timeout_guard = query_timeout.map(|t| timeout_manager.register(t));
+        let timeout_guard = register_query_timeout(&conn, query_timeout);
         inner_stmt.reset();
         let params = map_params(&inner_stmt, params)?;
         let rows = inner_stmt.query(params).await.map_err(Error::from)?;

--- a/src/query_timeout.rs
+++ b/src/query_timeout.rs
@@ -1,12 +1,16 @@
 use std::{
     cmp::Reverse,
-    collections::BinaryHeap,
-    sync::{Arc, Condvar, Mutex, Weak},
+    collections::{BinaryHeap, HashMap},
+    sync::{Arc, Condvar, Mutex, OnceLock, Weak},
     time::{Duration, Instant},
 };
 
-/// A single background thread with a timer wheel that interrupts a connection
-/// when the currently registered operation exceeds its deadline.
+/// A process-wide timer wheel: a single background thread that interrupts
+/// connections when their currently registered operation exceeds its deadline.
+///
+/// All connections share one manager — and therefore one thread. Each
+/// registered timeout carries a weak reference to the connection it should
+/// interrupt, so a single wheel serves any number of connections.
 pub struct QueryTimeoutManager {
     inner: Arc<Inner>,
 }
@@ -14,13 +18,16 @@ pub struct QueryTimeoutManager {
 struct Inner {
     state: Mutex<State>,
     cv: Condvar,
-    /// Connection to interrupt on timeout.
-    conn: Weak<libsql::Connection>,
 }
 
 struct State {
+    /// Pending deadlines, soonest first.
     heap: BinaryHeap<Reverse<Entry>>,
-    current_operation_id: Option<u64>,
+    /// Operations currently in flight, keyed by id. An expired entry is only
+    /// interrupted if it is still present here; a completed operation removes
+    /// itself via its guard's `Drop`, leaving a stale heap entry that is
+    /// discarded lazily when its deadline is reached.
+    active: HashMap<u64, Weak<libsql::Connection>>,
     next_id: u64,
     shutdown: bool,
 }
@@ -53,17 +60,24 @@ impl Ord for Entry {
     }
 }
 
+static GLOBAL: OnceLock<QueryTimeoutManager> = OnceLock::new();
+
 impl QueryTimeoutManager {
-    pub fn new(conn: &Arc<libsql::Connection>) -> Self {
+    /// Returns the process-wide timeout manager, spawning its single
+    /// background thread on first use.
+    pub fn global() -> &'static QueryTimeoutManager {
+        GLOBAL.get_or_init(QueryTimeoutManager::new)
+    }
+
+    pub fn new() -> Self {
         let inner = Arc::new(Inner {
             state: Mutex::new(State {
                 heap: BinaryHeap::new(),
-                current_operation_id: None,
+                active: HashMap::new(),
                 next_id: 0,
                 shutdown: false,
             }),
             cv: Condvar::new(),
-            conn: Arc::downgrade(conn),
         });
 
         let bg = Arc::downgrade(&inner);
@@ -75,27 +89,31 @@ impl QueryTimeoutManager {
     }
 
     /// Signal the background thread to exit and clear all entries.
+    ///
+    /// Only used to tear down standalone managers (e.g. in tests); the global
+    /// manager lives for the lifetime of the process.
     pub fn shutdown(&self) {
         {
             let mut state = self.inner.state.lock().unwrap();
             state.shutdown = true;
             state.heap.clear();
-            state.current_operation_id = None;
+            state.active.clear();
         }
         self.inner.cv.notify_one();
     }
 
-    /// Register a timeout for the currently executing operation.
-    pub fn register(&self, timeout: Duration) -> QueryTimeoutGuard {
+    /// Register a timeout for an operation about to run on `conn`. The returned
+    /// guard cancels the timeout when dropped (i.e. when the operation
+    /// completes).
+    pub fn register(
+        &self,
+        conn: &Arc<libsql::Connection>,
+        timeout: Duration,
+    ) -> QueryTimeoutGuard {
         let mut state = self.inner.state.lock().unwrap();
 
         let id = state.next_id;
         state.next_id += 1;
-
-        debug_assert!(
-            state.current_operation_id.is_none(),
-            "only one operation may be active per connection"
-        );
 
         let deadline = Instant::now()
             .checked_add(timeout)
@@ -107,10 +125,14 @@ impl QueryTimeoutManager {
             .peek()
             .map_or(true, |Reverse(existing)| entry.deadline < existing.deadline);
 
-        state.current_operation_id = Some(id);
+        state.active.insert(id, Arc::downgrade(conn));
         state.heap.push(Reverse(entry));
         drop(state);
 
+        // Only the soonest deadline dictates when the thread next wakes, so we
+        // only need to nudge it when this registration moves that deadline
+        // earlier. Guard drops never need to wake the thread: a cancelled entry
+        // is simply skipped when its (unchanged) deadline is reached.
         if is_new_earliest {
             self.inner.cv.notify_one();
         }
@@ -123,13 +145,10 @@ impl QueryTimeoutManager {
 
     fn deregister(inner: &Arc<Inner>, op_id: u64) {
         let mut state = inner.state.lock().unwrap();
-        if state.current_operation_id == Some(op_id) {
-            state.current_operation_id = None;
-        }
+        state.active.remove(&op_id);
     }
 
-    fn process_expired_deadlines(inner: &Arc<Inner>, state: &mut State) {
-        let mut should_interrupt = false;
+    fn process_expired_deadlines(state: &mut State) {
         let now = Instant::now();
 
         while let Some(Reverse(entry)) = state.heap.peek() {
@@ -143,14 +162,12 @@ impl QueryTimeoutManager {
                 .expect("heap peek succeeded but pop failed")
                 .0;
 
-            if state.current_operation_id == Some(entry.id) {
-                should_interrupt = true;
-            }
-        }
-
-        if should_interrupt {
-            if let Some(conn) = inner.conn.upgrade() {
-                let _ = conn.interrupt();
+            // Interrupt only if the operation is still in flight; a completed
+            // operation will have removed itself from `active` already.
+            if let Some(conn) = state.active.remove(&entry.id) {
+                if let Some(conn) = conn.upgrade() {
+                    let _ = conn.interrupt();
+                }
             }
         }
     }
@@ -183,7 +200,7 @@ impl QueryTimeoutManager {
                             }
                         }
 
-                        Self::process_expired_deadlines(&inner, &mut state);
+                        Self::process_expired_deadlines(&mut state);
                     }
                     None => {
                         state = inner.cv.wait(state).unwrap();
@@ -209,7 +226,6 @@ pub struct QueryTimeoutGuard {
 impl Drop for QueryTimeoutGuard {
     fn drop(&mut self) {
         QueryTimeoutManager::deregister(&self.inner, self.op_id);
-        self.inner.cv.notify_one();
     }
 }
 
@@ -229,9 +245,9 @@ mod tests {
     #[ntest::timeout(10000)]
     async fn deadline_expires_interrupts_connection() {
         let conn = test_conn().await;
-        let mgr = QueryTimeoutManager::new(&conn);
+        let mgr = QueryTimeoutManager::new();
 
-        let _guard = mgr.register(Duration::from_millis(200));
+        let _guard = mgr.register(&conn, Duration::from_millis(200));
 
         let fut = {
             let conn = conn.clone();
@@ -251,9 +267,9 @@ mod tests {
     #[ntest::timeout(10000)]
     async fn guard_dropped_before_deadline_cancels_timeout() {
         let conn = test_conn().await;
-        let mgr = QueryTimeoutManager::new(&conn);
+        let mgr = QueryTimeoutManager::new();
 
-        let guard = mgr.register(Duration::from_millis(200));
+        let guard = mgr.register(&conn, Duration::from_millis(200));
         drop(guard);
 
         std::thread::sleep(Duration::from_millis(300));
@@ -269,13 +285,13 @@ mod tests {
     #[ntest::timeout(10000)]
     async fn stale_deadline_does_not_interrupt_next_operation() {
         let conn = test_conn().await;
-        let mgr = QueryTimeoutManager::new(&conn);
+        let mgr = QueryTimeoutManager::new();
 
-        let guard = mgr.register(Duration::from_millis(200));
+        let guard = mgr.register(&conn, Duration::from_millis(200));
         drop(guard);
 
         // Register a second operation after the first one has been deregistered.
-        let _guard2 = mgr.register(Duration::from_millis(5000));
+        let _guard2 = mgr.register(&conn, Duration::from_millis(5000));
 
         std::thread::sleep(Duration::from_millis(300));
 
@@ -283,6 +299,44 @@ mod tests {
         assert!(
             result.is_ok(),
             "stale timeout entry should not interrupt a different operation"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ntest::timeout(10000)]
+    async fn one_wheel_serves_many_connections() {
+        let mgr = QueryTimeoutManager::new();
+
+        // A short-deadline operation on one connection must be interrupted...
+        let slow_conn = test_conn().await;
+        let _slow_guard = mgr.register(&slow_conn, Duration::from_millis(200));
+
+        // ...while a long-deadline operation on a different connection,
+        // registered through the same manager, is left untouched.
+        let fast_conn = test_conn().await;
+        let _fast_guard = mgr.register(&fast_conn, Duration::from_millis(60_000));
+
+        let slow = {
+            let slow_conn = slow_conn.clone();
+            tokio::spawn(async move {
+                slow_conn
+                    .execute_batch(
+                        "WITH RECURSIVE r(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM r) SELECT * FROM r",
+                    )
+                    .await
+            })
+        };
+
+        let slow_result = slow.await.unwrap();
+        assert!(
+            slow_result.is_err(),
+            "the short-deadline connection should have been interrupted"
+        );
+
+        let fast_result = fast_conn.execute_batch("SELECT 1").await;
+        assert!(
+            fast_result.is_ok(),
+            "a different connection sharing the wheel should not be interrupted"
         );
     }
 }


### PR DESCRIPTION
Each connection previously constructed its own QueryTimeoutManager, and
since pre.36 that manager spawns a dedicated std::thread. The result was
one OS thread per open connection, exhausting the process thread limit
after a few hundred connections (pre.33 used a tokio task and opened
1500+ cleanly).

Make QueryTimeoutManager a process-wide singleton with one background
thread. Each registered timeout now carries a Weak<Connection> on its
heap entry, so a single wheel interrupts the right connection regardless
of how many are open. Connections no longer hold a manager or shut one
down on close.

Also add an integration test that opens many connections at once as a
reproducer for the exhaustion.
